### PR TITLE
Speed up CI using docker caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM fedora:rawhide
 MAINTAINER Vadim Rutkovsky <vrutkovs@redhat.com>
 
-ADD . /opt/gnome-news/
-WORKDIR /opt/gnome-news/
-
 # Install dependencies
 RUN dnf install -y libappstream-glib-devel autoconf autoconf-archive automake \
     intltool gcc glib2-devel make findutils tar xz
+
+ADD . /opt/gnome-news/
+WORKDIR /opt/gnome-news/
 
 # Build
 RUN ./autogen.sh && make


### PR DESCRIPTION
Installed packages would be cached, making build pass in ~20 secs
instead of average of 3 mins.

See https://circleci.com/gh/vrutkovs/gnome-news/46
